### PR TITLE
Fix #70 - prints error message on update_build_status_fail

### DIFF
--- a/DRS-BATCH-PROCESSING/commonUtils.sh
+++ b/DRS-BATCH-PROCESSING/commonUtils.sh
@@ -3,15 +3,9 @@
 #
 # Argument is the first token in a line. Tests for it to be a magic header
 function isNewHeaderLine {
-
     seekTok=WorkName
-
-    declare -a argA=("${!1}")
-    if [ "${argA[0]}" = "${seekTok}" ] ; then
-        return 0 ;
-    else
-        return 1 ;
-    fi
+    declare -a argA=$1
+    [ "${argA[0]}" == "${seekTok}" ]
 }
 
 #


### PR DESCRIPTION
Fixes bugs #70 and #92
- can now recognize internal Work separator line
- eliminate noise when an imagegroup is not found