### PR TITLE
fixes drs-deposit#95 prevents errors with the -p flag and empty worksFn

### DIFF
--- a/DRS-BATCH-PROCESSING/splitWorks.sh
+++ b/DRS-BATCH-PROCESSING/splitWorks.sh
@@ -68,7 +68,7 @@ sourceFile=$1
 # Give worksFn a default, if none
 srcBase=$(basename $sourceFile)
 # Take only the first segment with %%
-worksFn=${worksFn:-${srcBase%%.*}}"."
+worksFn=${worksFn:-Split${srcBase%%.*}}"."
 
 fileCount=$(($(wc -l < $sourceFile)))
 #


### PR DESCRIPTION
fixes #95 preventing errors with the -p flag and empty worksFn