### PR TITLE
drs-deposit-106 Provide default config for DB facing calls

### DIFF
--- a/DBAppParser/.gitignore
+++ b/DBAppParser/.gitignore
@@ -1,4 +1,10 @@
 # Created by .ignore support plugin (hsz.mobi)
+
+# Pytyhon stuff
+**/venv/**
+**/build/**
+**/dist/**
+**/*.egg-info/**
 ### Python template
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/DBAppParser/setup.py
+++ b/DBAppParser/setup.py
@@ -4,17 +4,17 @@ long_description = '# BDRC DBApp Parser ' \
                    'Basic parsers for db apps. Library only'
 setup(
     name='bdrc-DBAppParser',
-    version='1.00.02',
+    version='1.00.04',
     packages=find_packages(),
     url='',
     license='MIT',
     author='jimk',
     author_email='jimk@tbrc.org',
-    description='# BDRC DbApp Parser. Common arg parsing libraries',
+    description='# BDRC DbApp Parser'
+                'Common arg parsing libraries for bdrc-utils',
     long_description=long_description,
     long_description_content_type='text/markdown',
     python_requires='>=3.7',
-    # install_requires=['pymysql', 'lxml', 'bdrc-DBAppParser'],
     classifiers=["Programming Language :: Python :: 3", "License :: OSI Approved :: MIT License",
                  "Operating System :: MacOS :: MacOS X", "Operating System :: OS Independent",
                  "Development Status :: 5 - Production/Stable"]

--- a/DBAppParser/test/test_dbapp_parser.sh
+++ b/DBAppParser/test/test_dbapp_parser.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# Test bdrc app parser  on DB Apps
+#
+#set -v
+#set -x
+
+
+#Create a tmp place
+home_d=$(mktemp -d)
+
+pushd $home_d
+python3 -m venv py-test
+. py-test/bin/activate
+# Install the test subject
+pip install --force-reinstall --no-cache-dir -i https://test.pypi.org/simple/ bdrc-DBAppParser
+#
+# Install a test suite. Shouldn't reinstall bdrcDBApps
+pip install --no-cache-dir bdrc-DBApps
+
+default_db_config=~/.config/bdrc/db_apps.config
+non_exist_config=/dev/null/db_config
+
+
+which getReadyRelated
+test_comment="Test using default_db_config ${default_db_config}"
+if [ -r  "${default_db_config}" ] ; then
+    echo Testing default config
+    getReadyRelated -o -n 4 grr
+    tr=PASS
+    if ! grep 'WorkName,HOLLIS' grr ; then
+      tr=FAIL
+    fi
+    echo $tr $test_comment
+fi
+
+test_comment="Test using known nonexistent config"
+rm grr
+tr=PASS
+if getReadyRelated -d fake:${non_exist_config}  -o -n 3 grr ; then
+  tr=FAIL
+fi
+echo $tr $test_comment
+#
+deactivate
+popd
+rm -rf $home_d
+echo $home_d
+
+
+
+
+
+
+
+

--- a/DBAppParser/test/test_dbapp_parser_utils.sh
+++ b/DBAppParser/test/test_dbapp_parser_utils.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# Test bdrc app parser on DBApps
+#
+#Create a tmp place
+
+#set -v
+#set -x
+
+
+home_d=$(mktemp -d)
+
+pushd $home_d
+echo
+echo
+echo
+python3 -m venv py-test
+. py-test/bin/activate
+# Install the test subject
+pip install --force-reinstall --no-cache-dir -i https://test.pypi.org/simple/ bdrc-DBAppParser==1.0.4
+#
+# Install a test suite. Shouldn't reinstall bdrcDBApps
+pip install --no-cache-dir bdrc-util
+
+default_db_config=~/.config/bdrc/db_apps.config
+non_exist_config=/dev/null/db_config
+
+b_date1="2001-01-01 00:00:01"
+b_date2="2001-02-02 00:00:02"
+
+e_date1="2001-03-03 00:00:03"
+e_date2="2001-04-04 00:00:04"
+
+which log_dip
+
+test_comment="Test using default_db_config ${default_db_config}"
+if [ -r  "${default_db_config}" ] ; then
+    echo Testing default config
+     expected_=$(log_dip -b "${b_date1}" -e "${e_date1}" -a DRS -w NoWork -r 1  "NoRealPathSource" "NoRealPathDest")
+    tr=PASS
+    if [[ -z ${expected_} ]] ; then
+      tr=FAIL
+    fi
+    echo $tr $test_comment
+fi
+
+test_comment="Test using known nonexistent config"
+tr=PASS
+expected_=$(log_dip -d frelm:${non_exist_config} -b "${b_date2}" -e "${e_date2}" -a DRS -w NoWork -r 2)
+if [ ! -n ${expected_} ]; then
+  tr=FAIL
+fi
+echo $tr $test_comment
+
+deactivate
+popd
+rm -rf $home_d
+
+
+
+
+
+
+
+


### PR DESCRIPTION
Fixes #106 

Installed into pyPI
View at:
    https://pypi.org/project/bdrc-DBAppParser/1.0.4/

Installation:
pip install --upgrade  bdrc-DBAppParser==1.0.4

It's optional, but you can also re-install bdrc-util from the production pyPI (`pip install --upgrade --no-cache-dir  bdrc-util`) instead of using the test install (the bits are identical)